### PR TITLE
Align with sequencer disputes auto-close behaviour

### DIFF
--- a/test/rollup/rollup.cancel.test.ts
+++ b/test/rollup/rollup.cancel.test.ts
@@ -66,11 +66,15 @@ describe("Rollup", () => {
       );
       //wait for the update to be in contract
       await waitForBatchWithRequest(nToBigInt(id), getL1("EthAnvil")!);
-      //run close.
-      await Rolldown.closeCancelOnL1(
-        nToBigInt(id),
-        getL1("EthAnvil")!.gaspName,
-      );
+
+      // FIXME: sequencer should close cancel automatically so maybe instead 
+      // test should wait for that to happen on L1 ?
+      //
+      // await Rolldown.closeCancelOnL1(
+      //   nToBigInt(id),
+      //   getL1("EthAnvil")!.gaspName,
+      // );
+
       await waitForEvents(
         await getApi(),
         "sequencerStaking.SequencersRemovedFromActiveSet",


### PR DESCRIPTION
(tested locally with docker setup from `feature/rust-sequencer`) 


https://github.com/gasp-xyz/gasp-monorepo/pull/307

https://github.com/gasp-xyz/gasp-monorepo/actions/runs/11941247864/job/33305914379?pr=307