### PR TITLE
make tool work with capitals provided in address

### DIFF
--- a/cliTool/index.ts
+++ b/cliTool/index.ts
@@ -1049,7 +1049,8 @@ async function app(): Promise<any> {
             }
 
             const res = deposits.filter(
-              (r) => r.data.address === answers.address,
+              (r) =>
+                r.data.address.toLowerCase() === answers.address.toLowerCase(),
             );
             console.log(res);
 

--- a/cliTool/index.ts
+++ b/cliTool/index.ts
@@ -1087,7 +1087,8 @@ async function app(): Promise<any> {
             }
 
             const res = withdrawals.filter(
-              (r) => r.data.address === answers.address,
+              (r) =>
+                r.data.address.toLowerCase() === answers.address.toLowerCase(),
             );
 
             console.log(res);


### PR DESCRIPTION
This PR fixes an issue, when capitals were in provided address, an empty array was returned.